### PR TITLE
adding support for fish shell to aws-agent

### DIFF
--- a/awsudo.gemspec
+++ b/awsudo.gemspec
@@ -1,5 +1,5 @@
 PKG_NAME = 'awsudo'
-PKG_VERSION = '1.0.1'
+PKG_VERSION = '1.0.2'
 PKG_FILES = Dir['bin/*'] + ['lib/awsudo.rb'] + %w{LICENSE CHANGELOG.md CONTRIBUTING.md README.md}
 
 spec = Gem::Specification.new do |s|

--- a/bin/aws-agent
+++ b/bin/aws-agent
@@ -28,11 +28,16 @@ username, password = AWSUDO.get_federated_credentials
 
 socket_dir  = Dir.mktmpdir("aws-")
 socket_name = File.join(socket_dir, "agent")
-if ENV['SHELL'].split('/').last == 'fish'
+
+case ENV['SHELL'].split('/').last
+when 'csh', 'tcsh'
+  puts "setenv AWS_AUTH_SOCK #{socket_name}"
+when 'fish'
   puts "set -gx AWS_AUTH_SOCK #{socket_name}"
 else
   puts "AWS_AUTH_SOCK=#{socket_name}; export AWS_AUTH_SOCK;"
 end
+
 Process.daemon
 $0 = 'aws-agent'
 Process.setrlimit(Process::RLIMIT_CORE, 0, 0)

--- a/bin/aws-agent
+++ b/bin/aws-agent
@@ -28,7 +28,11 @@ username, password = AWSUDO.get_federated_credentials
 
 socket_dir  = Dir.mktmpdir("aws-")
 socket_name = File.join(socket_dir, "agent")
-puts "AWS_AUTH_SOCK=#{socket_name}; export AWS_AUTH_SOCK;"
+if ENV['SHELL'].split('/').last == 'fish'
+  puts "set -gx AWS_AUTH_SOCK #{socket_name}"
+else
+  puts "AWS_AUTH_SOCK=#{socket_name}; export AWS_AUTH_SOCK;"
+end
 Process.daemon
 $0 = 'aws-agent'
 Process.setrlimit(Process::RLIMIT_CORE, 0, 0)


### PR DESCRIPTION
Just updating the syntax for the AWS_AUTH_SOCK environment var to something that Fish shell can work with.
