### PR TITLE
[boto2_support] added AWS_SECURITY_TOKEN environment variable for boto2

### DIFF
--- a/bin/awsudo
+++ b/bin/awsudo
@@ -30,5 +30,6 @@ credentials =
 ENV['AWS_ACCESS_KEY_ID'] = credentials['access_key_id'] || credentials[:access_key_id]
 ENV['AWS_SECRET_ACCESS_KEY'] = credentials['secret_access_key'] || credentials[:secret_access_key]
 ENV['AWS_SESSION_TOKEN'] = credentials['session_token'] || credentials[:session_token]
+ENV['AWS_SECURITY_TOKEN'] = credentials['session_token'] || credentials[:session_token] # For boto2
 
 exec *ARGV if ARGV.size > 0


### PR DESCRIPTION
boto2 used AWS_SECURITY_TOKEN instead of AWS_SESSION_TOKEN (although boto3 made the switch to standardise with other SDKs).

This change enables awsudo to work with boto2 based tools and programs.
